### PR TITLE
feat: mount RSA signing key from Secret; document JWT/JWKS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,38 @@ This is a [Helm Chart](https://helm.sh/docs/topics/charts/) for [Krateo AuthN](h
 
 ## Requirements
 
-A Secret called 'jwt-sign-key' must exist within the same namespace where 'authn' will be deployed.
-This Secret will container the key for the jwt authentication.
-Here's an example of the Secret yaml:
+authn signs JWTs asymmetrically with **RS256** and publishes the matching public
+key as a JWKS at `GET /.well-known/jwks.json`. Before installing, a Secret holding
+the **PEM-encoded RSA private key** must exist in the release namespace.
 
+By default the chart expects a Secret named `jwt-sign-key` with the key under
+`private.pem` (configurable via `jwt.signKeySecretName` / `jwt.signKeySecretKey`).
+The Secret is mounted into the pod as a file at `/etc/authn/jwt/private.pem` and
+exposed to the process via `JWT_SIGN_KEY_FILE` — it is **not** injected as an
+environment variable value.
+
+Generate a keypair and create the Secret:
+
+```sh
+# 1. Generate a 2048-bit RSA private key (the public half is derived by authn).
+openssl genrsa -out private.pem 2048
+
+# 2. Create the Secret from that file. The key name (private.pem) must match
+#    .Values.jwt.signKeySecretKey.
+kubectl create secret generic jwt-sign-key \
+  --namespace <authn-namespace> \
+  --from-file=private.pem=./private.pem
 ```
-apiVersion: v1
-kind: Secret
-metadata:
-  name: jwt-sign-key
-type: Opaque
-stringData:
-  JWT_SIGN_KEY: AbbraCadabbra
-```
+
+You must also set a stable key ID (`kid`) via `jwt.kid` (default
+`krateo-authn-key-1`). It is stamped into every token header and the JWKS, and
+validators use it to select the key — keep it constant for the key's lifetime.
+
+> **Migrating from HS256?** Earlier versions used a shared symmetric secret
+> (`stringData.JWT_SIGN_KEY`). That is no longer supported: replace the Secret
+> with the PEM private key shown above. See
+> [`authn/docs/jwt-jwks.md`](https://github.com/krateoplatformops/authn/blob/main/docs/jwt-jwks.md)
+> for the full JWT/JWKS reference, including agentgateway and Snowplow wiring.
 
 ## How to install
 

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -35,8 +35,11 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "authn.fullname" . }}
-            - secretRef:
-                name: {{ .Values.jwtSignKeySecretName }}
+          env:
+            - name: JWT_SIGN_KEY_FILE
+              value: "{{ .Values.jwt.mountPath }}/{{ .Values.jwt.signKeySecretKey }}"
+            - name: JWT_KID
+              value: {{ .Values.jwt.kid | quote }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -51,14 +54,23 @@ spec:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- with .Values.volumeMounts }}
           volumeMounts:
+            - name: jwt-sign-key
+              mountPath: {{ .Values.jwt.mountPath }}
+              readOnly: true
+            {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
-      {{- with .Values.volumes }}
+            {{- end }}
       volumes:
+        - name: jwt-sign-key
+          secret:
+            secretName: {{ .Values.jwt.signKeySecretName }}
+            items:
+              - key: {{ .Values.jwt.signKeySecretKey }}
+                path: {{ .Values.jwt.signKeySecretKey }}
+        {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -115,4 +115,19 @@ env:
   AUTHN_CORS: "true"
   AUTHN_DUMP_ENV: "true"
 
-jwtSignKeySecretName: jwt-sign-key
+# JWT signing key configuration.
+# authn signs tokens with an RSA private key (RS256) and publishes the matching
+# public key as a JWKS at GET /.well-known/jwks.json. The private key is mounted
+# from a Secret as a file (never injected as an env var).
+jwt:
+  # Name of the Secret holding the PEM-encoded RSA private key.
+  signKeySecretName: jwt-sign-key
+  # Key inside that Secret whose value is the PEM private key; it is also the
+  # mounted filename.
+  signKeySecretKey: private.pem
+  # Directory the Secret is mounted into. The container reads
+  # <mountPath>/<signKeySecretKey> (exposed as JWT_SIGN_KEY_FILE).
+  mountPath: /etc/authn/jwt
+  # Key ID advertised in every token header and in the JWKS "kid". Must be
+  # stable for the lifetime of the key so validators can match it.
+  kid: krateo-authn-key-1


### PR DESCRIPTION
Mount the PEM private key as a file (JWT_SIGN_KEY_FILE) instead of injecting a shared secret env var, add JWT_KID, and document key/Secret creation.